### PR TITLE
Improve test coverage

### DIFF
--- a/helper_test.go
+++ b/helper_test.go
@@ -53,9 +53,9 @@ func TestHelper(t *testing.T) {
 
 			g.Describe(`without an ipv4 address`, func() {
 				g.It(`returns an error`, func() {
-					data := decodeMetadata(`{"interfaces": {"public": [{"ipv4": {"ip_address": "publicIP"}}]}}`)
+					data := decodeMetadata(`{"interfaces": {"private": [{"ipv6": {"ip_address": "privateIP"}}]}}`)
 					_, err := LocalAddress(data)
-					g.Assert(err).Equal(errors.New(`no private interfaces`))
+					g.Assert(err).Equal(errors.New(`no ipv4 private iface`))
 				})
 			})
 		})

--- a/tables_test.go
+++ b/tables_test.go
@@ -66,6 +66,18 @@ func TestTables(t *testing.T) {
 			})
 		})
 
+		g.Describe("when adding the established connection rule errors", func() {
+			g.It("returns the error", func() {
+				sipt.appendUnique = func(a, b string, c ...string) error {
+					if a == "filter" && b == "INPUT" && len(c) == 8 {
+						return errors.New("bad connect rule")
+					}
+					return nil
+				}
+				g.Assert(Setup(sipt, "eth1")).Equal(errors.New("bad connect rule"))
+			})
+		})
+
 		g.Describe(`when adding the deny rule errors`, func() {
 			g.It(`returns the error`, func() {
 				sipt.appendUnique = func(a, b string, c ...string) error {


### PR DESCRIPTION
test only: 56.9% to 60.8%

Investigated stubbing `net.Interface` in `PrivateInterface`, but since `net.Interface` _isnt_ an interface it would require more code/indirection than its worth.
