### PR TITLE
permit access based on a single tag

### DIFF
--- a/main.go
+++ b/main.go
@@ -27,6 +27,8 @@ func main() {
 		log.Fatal(`Usage: DO_KEY environment variable must be set.`)
 	}
 
+	peerTag := os.Getenv(`DO_TAG`)
+
 	// setup dependencies
 	oauthClient := oauth2.NewClient(oauth2.NoContext, oauth2.StaticTokenSource(&oauth2.Token{AccessToken: accessToken}))
 	apiClient := godo.NewClient(oauthClient)
@@ -41,7 +43,12 @@ func main() {
 	failIfErr(err)
 
 	// collect list of all droplets
-	drops, err := DropletList(apiClient.Droplets)
+	var drops []godo.Droplet
+	if peerTag != "" {
+		drops, err = DropletListTags(apiClient.Droplets, peerTag)
+	} else {
+		drops, err = DropletList(apiClient.Droplets)
+	}
 	failIfErr(err)
 
 	allowed, ok := SortDroplets(drops)[region]

--- a/peers.go
+++ b/peers.go
@@ -59,3 +59,40 @@ func DropletList(ds godo.DropletsService) ([]godo.Droplet, error) {
 
 	return list, nil
 }
+
+// DropletListTags paginates through the digitalocean API to return a list of
+// all droplets with the given tag
+func DropletListTags(ds godo.DropletsService, tag string) ([]godo.Droplet, error) {
+	// create a list to hold our droplets
+	list := []godo.Droplet{}
+
+	// create options. initially, these will be blank
+	opt := &godo.ListOptions{}
+	for {
+		droplets, resp, err := ds.ListByTag(tag, opt)
+
+		if err != nil {
+			return nil, err
+		}
+
+		// append the current page's droplets to our list
+		for _, d := range droplets {
+			list = append(list, d)
+		}
+
+		// if we are at the last page, break out the for loop
+		if resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
+
+		page, err := resp.Links.CurrentPage()
+		if err != nil {
+			return nil, err
+		}
+
+		// set the page we want for the next request
+		opt.Page = page + 1
+	}
+
+	return list, nil
+}


### PR DESCRIPTION
Addresses https://github.com/tam7t/droplan/issues/17

If the `DO_TAG` environment variable is set, use that tag to search for peers that should be given access.
