### PR TITLE
examples: update to include filtering by tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ The `iptables` rules added by `droplan` are equivalent to:
 -A droplan-peers -s <PEER>/32 -j ACCEPT # allow traffic from PEER ip address
 ```
 
+Access can be limited to a subset of droplets using [tags](https://developers.digitalocean.com/documentation/v2/#tags).
+The `DO_TAG` environment variable tells `droplan` to only allow access to
+droplets with the specified tag.
+
 ## Development
 
 ### Dependencies

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -2,6 +2,10 @@ provider "digitalocean" {
   token = "${var.do_token}"
 }
 
+resource "digitalocean_tag" "droplan" {
+  name = "droplantag"
+}
+
 resource "digitalocean_ssh_key" "root_ssh" {
   name = "Terraform Root SSH Key"
   public_key = "${file(var.ssh_key_path)}"
@@ -14,14 +18,15 @@ resource "digitalocean_droplet" "droplan-ubuntu-x64" {
   size = "512mb"
   private_networking = true
   ssh_keys = ["${digitalocean_ssh_key.root_ssh.id}"]
+  tags = ["${digitalocean_tag.droplan.id}"]
 
   provisioner "remote-exec" {
     inline = [
       "cd /tmp",
-      "curl -O -L https://github.com/tam7t/droplan/releases/download/v1.0.1/droplan_1.0.1_linux_amd64.tar.gz",
-      "tar -zxf droplan_1.0.1_linux_amd64.tar.gz -C /usr/local/bin",
-      "rm /tmp/droplan_1.0.1_linux_amd64.tar.gz",
-      "echo '${template_file.cron.rendered}' > /etc/cron.d/droplan"
+      "curl -O -L https://github.com/tam7t/droplan/releases/download/v1.1.0/droplan_1.1.0_linux_amd64.tar.gz",
+      "tar -zxf droplan_1.1.0_linux_amd64.tar.gz -C /usr/local/bin",
+      "rm /tmp/droplan_1.1.0_linux_amd64.tar.gz",
+      "echo '${data.template_file.cron.rendered}' > /etc/cron.d/droplan"
     ]
   }
 }
@@ -33,14 +38,15 @@ resource "digitalocean_droplet" "droplan-ubuntu-x32" {
   size = "512mb"
   private_networking = true
   ssh_keys = ["${digitalocean_ssh_key.root_ssh.id}"]
+  tags = ["${digitalocean_tag.droplan.id}"]
 
   provisioner "remote-exec" {
     inline = [
       "cd /tmp",
-      "curl -O -L https://github.com/tam7t/droplan/releases/download/v1.0.1/droplan_1.0.1_linux_386.tar.gz",
-      "tar -zxf droplan_1.0.1_linux_386.tar.gz -C /usr/local/bin",
-      "rm /tmp/droplan_1.0.1_linux_386.tar.gz",
-      "echo '${template_file.cron.rendered}' > /etc/cron.d/droplan"
+      "curl -O -L https://github.com/tam7t/droplan/releases/download/v1.1.0/droplan_1.1.0_linux_386.tar.gz",
+      "tar -zxf droplan_1.1.0_linux_386.tar.gz -C /usr/local/bin",
+      "rm /tmp/droplan_1.1.0_linux_386.tar.gz",
+      "echo '${data.template_file.cron.rendered}' > /etc/cron.d/droplan"
     ]
   }
 }
@@ -52,21 +58,42 @@ resource "digitalocean_droplet" "droplan-fedora-x64" {
   size = "512mb"
   private_networking = true
   ssh_keys = ["${digitalocean_ssh_key.root_ssh.id}"]
+  tags = ["${digitalocean_tag.droplan.id}"]
 
   provisioner "remote-exec" {
     inline = [
-      "curl -O -L https://github.com/tam7t/droplan/releases/download/v1.0.1/droplan_1.0.1_linux_amd64.tar.gz",
-      "tar -zxf droplan_1.0.1_linux_amd64.tar.gz -C /usr/local/bin",
-      "rm droplan_1.0.1_linux_amd64.tar.gz",
-      "echo '${template_file.cron.rendered}' > /etc/cron.d/droplan"
+      "curl -O -L https://github.com/tam7t/droplan/releases/download/v1.1.0/droplan_1.1.0_linux_amd64.tar.gz",
+      "tar -zxf droplan_1.1.0_linux_amd64.tar.gz -C /usr/local/bin",
+      "rm droplan_1.1.0_linux_amd64.tar.gz",
+      "echo '${data.template_file.cron.rendered}' > /etc/cron.d/droplan"
     ]
   }
 }
 
-resource "template_file" "cron" {
+resource "digitalocean_droplet" "droplan-ubuntu-x64-notag" {
+  image = "ubuntu-14-04-x64"
+  name = "droplan-ubuntu-x64-notag"
+  region = "nyc3"
+  size = "512mb"
+  private_networking = true
+  ssh_keys = ["${digitalocean_ssh_key.root_ssh.id}"]
+
+  provisioner "remote-exec" {
+    inline = [
+      "cd /tmp",
+      "curl -O -L https://github.com/tam7t/droplan/releases/download/v1.1.0/droplan_1.1.0_linux_amd64.tar.gz",
+      "tar -zxf droplan_1.1.0_linux_amd64.tar.gz -C /usr/local/bin",
+      "rm /tmp/droplan_1.1.0_linux_amd64.tar.gz",
+      "echo '${data.template_file.cron.rendered}' > /etc/cron.d/droplan"
+    ]
+  }
+}
+
+data "template_file" "cron" {
   template = "${file("${path.module}/templates/cron.tpl")}"
 
   vars {
     key = "${var.droplan_token}"
+    tag = "${digitalocean_tag.droplan.id}"
   }
 }

--- a/examples/templates/cron.tpl
+++ b/examples/templates/cron.tpl
@@ -1,1 +1,1 @@
-*/5 * * * * root PATH=/sbin DO_KEY=${key} /usr/local/bin/droplan >/var/log/droplan.log 2>&1
+*/5 * * * * root PATH=/sbin DO_KEY=${key} DO_TAG=${tag} /usr/local/bin/droplan >/var/log/droplan.log 2>&1


### PR DESCRIPTION
update example with version `1.1.0` and `DO_TAG` usage. Requires terraform `0.7.x`
