### PR TITLE
Improved docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,11 @@
-FROM golang:alpine
-RUN apk add --no-cache iptables ca-certificates git && \
+FROM alpine:3.4
+RUN apk add --no-cache iptables ca-certificates && \
 	update-ca-certificates
 
 ENV DO_KEY ""
 ENV DO_TAG ""
 
-RUN ln -s go/src/github.com/tam7t/droplan/ /droplan
-COPY ./ /go/src/github.com/tam7t/droplan/
+ADD droplan /droplan
+ADD docker-run.sh /docker-run.sh
 
-WORKDIR /droplan
-RUN go get -u github.com/kardianos/govendor
-RUN govendor build
-
-ENTRYPOINT ["/droplan/docker-run.sh"]
+CMD ["/docker-run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,15 @@
-FROM alpine:3.4
-RUN apk add --no-cache iptables ca-certificates && \
+FROM golang:alpine
+RUN apk add --no-cache iptables ca-certificates git && \
 	update-ca-certificates
 
 ENV DO_KEY ""
 ENV DO_TAG ""
 
-ADD droplan /droplan
-ENTRYPOINT ["/droplan"]
+RUN ln -s go/src/github.com/tam7t/droplan/ /droplan
+COPY ./ /go/src/github.com/tam7t/droplan/
+
+WORKDIR /droplan
+RUN go get -u github.com/kardianos/govendor
+RUN govendor build
+
+ENTRYPOINT ["/droplan/docker-run.sh"]

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,10 @@ build:
 	go build .
 
 build-amd64:
-	@docker run -it --rm -v `pwd`:/go/src/github.com/tam7t/droplan -w /go/src/github.com/tam7t/droplan golang:latest env GOOS=linux GOARCH=amd64 go build -ldflags="-X main.appVersion=${DROPLAN_VERSION}" -o droplan
+	@docker run -it --rm -v `pwd`:/go/src/github.com/tam7t/droplan -w /go/src/github.com/tam7t/droplan golang:alpine env GOOS=linux GOARCH=amd64 go build -ldflags="-X main.appVersion=${DROPLAN_VERSION}" -o droplan
 
 build-i386:
-	@docker run -it --rm -v `pwd`:/go/src/github.com/tam7t/droplan -w /go/src/github.com/tam7t/droplan golang:latest env GOOS=linux GOARCH=386 go build -ldflags="-X main.appVersion=${DROPLAN_VERSION}" -o droplan_i386
+	@docker run -it --rm -v `pwd`:/go/src/github.com/tam7t/droplan -w /go/src/github.com/tam7t/droplan golang:alpine env GOOS=linux GOARCH=386 go build -ldflags="-X main.appVersion=${DROPLAN_VERSION}" -o droplan_i386
 
 release: build-amd64 build-i386
 	@zip droplan_${DROPLAN_VERSION}_linux_amd64.zip droplan

--- a/README.md
+++ b/README.md
@@ -60,19 +60,21 @@ A `Makefile` is included:
 
 ## Docker image:
 
-There's a prebuilt [docker image][1] (currently it's third party, but I hope it'll get merged back to tam7t/droplan).
+We provice a prebuilt [docker image][1]
 
 Example usage:
 
 ```sh
-docker run -d --restart=always --net=host -e DO_KEY=$your_digitalocean_api_key tam7t/droplan
+docker run -d --restart=always --net=host --cap-add=NET_ADMIN -e DO_KEY=$your_digitalocean_api_key tam7t/droplan
 ```
 
-- `-d --restart=always` starts the container in the background and restarts it on error
+- `-d --restart=always` starts the container in the background and restarts it on error (and on reboot)
 - `--net=host` is required because we want to affect the host's firewall rules, not the container's
+- `--cap-add=NET_ADMIN` to allow changing the host's firewall rules
 - you have to specify your DigitalOcean API key (using `-e DO_KEY`)
 - you can add `-e PUBLIC=true` or `-e DO_TAG=tagname` as described above
 - specify `-e DO_INTERVAL=120` to change the delay between droplan invocations (default: '300' (5 minutes) ) 
+- To manually start droplan (i.e. skip the 5 minute delay between invocations), simply use `docker restart $container-name`
 
 
 [1]: https://hub.docker.com/r/tam7t/droplan/

--- a/README.md
+++ b/README.md
@@ -56,3 +56,28 @@ A `Makefile` is included:
   * `test` - runs unit tests
   * `build` - builds `droplan` on the current platform
   * `release` - builds releasable artifacts
+
+
+## Docker image:
+
+There's a prebuilt [docker image][1] (currently it's third party, but I hope it'll get merged back to tam7t/droplan).
+
+Example usage:
+
+```sh
+docker run -d --restart=always --net=host -e DO_KEY=$your_digitalocean_api_key mreithub/droplan
+```
+
+- `-d --restart=always` starts the container in the background and restarts it on error
+- `--net=host` is required because we want to affect the host's firewall rules, not the container's
+- you have to specify your DigitalOcean API key (using `-e DO_KEY`)
+- you can add `-e PUBLIC=true` or `-e DO_TAG=tagname` as described above
+
+
+Note: The differences of this image compared to the original [tam7t/droplan][2] are (as of the time of this writing):
+- added `docker-run.sh` which periodically invokes the droplan utility (using `$DO_INTERVAL` as delay between invocations)
+- automated the docker build (instead of copying the compiled binary, we acutally compile inside the 
+- Using automated builds also means that this `README.md` will be used as long description of the docker 
+
+[1]: https://hub.docker.com/r/mreithub/droplan/
+[2]: https://hub.docker.com/r/tam7t/droplan/

--- a/README.md
+++ b/README.md
@@ -65,19 +65,14 @@ There's a prebuilt [docker image][1] (currently it's third party, but I hope it'
 Example usage:
 
 ```sh
-docker run -d --restart=always --net=host -e DO_KEY=$your_digitalocean_api_key mreithub/droplan
+docker run -d --restart=always --net=host -e DO_KEY=$your_digitalocean_api_key tam7t/droplan
 ```
 
 - `-d --restart=always` starts the container in the background and restarts it on error
 - `--net=host` is required because we want to affect the host's firewall rules, not the container's
 - you have to specify your DigitalOcean API key (using `-e DO_KEY`)
 - you can add `-e PUBLIC=true` or `-e DO_TAG=tagname` as described above
+- specify `-e DO_INTERVAL=120` to change the delay between droplan invocations (default: '300' (5 minutes) ) 
 
 
-Note: The differences of this image compared to the original [tam7t/droplan][2] are (as of the time of this writing):
-- added `docker-run.sh` which periodically invokes the droplan utility (using `$DO_INTERVAL` as delay between invocations)
-- automated the docker build (instead of copying the compiled binary, we acutally compile inside the 
-- Using automated builds also means that this `README.md` will be used as long description of the docker 
-
-[1]: https://hub.docker.com/r/mreithub/droplan/
-[2]: https://hub.docker.com/r/tam7t/droplan/
+[1]: https://hub.docker.com/r/tam7t/droplan/

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+set -ex
+
+if [ -z "$DO_INTERVAL" ]; then
+	# specifies the check interval
+	DO_INTERVAL=300
+fi
+
+while true; do
+	# since we use 'set -e', this while loop will exit if droplan exits with a return value other than 0
+	# (which in turn tells docker to restart the container (assuming the --restart option was used)
+	# while delaying retries exponentially)
+	./droplan "$@"
+	sleep "$DO_INTERVAL"
+done


### PR DESCRIPTION
I've taken the liberty of rewriting the `Dockerfile` so that it can be built automatically on docker hub (I've got my own clone of this [here][1] in case you're interested).

I've also added a wrapper script (`docker-run.sh`) that periodically invokes `droplan` (the interval can be specified using `$DO_INTERVAL`).

Also, I've added a paragraph about using the docker image to `README.md`

The example command I've added to `README.md` should be enough to have the tool restart on reboot, be executed in a 5 minute interval, etc.

Let me know if there's anything you want me to add and/or change.

[1]: https://hub.docker.com/r/mreithub/droplan/