### PR TITLE
main: exit gracefully if no private iface

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ A `Makefile` is included:
 
 ## Docker image:
 
-We provice a prebuilt [docker image][1]
+We provide a prebuilt [docker image][1]
 
 Example usage:
 

--- a/main.go
+++ b/main.go
@@ -88,6 +88,9 @@ func main() {
 
 	// find private iface name
 	iface, err := FindInterfaceName(ifaces, privAddr)
+	if public != "" && err != nil && err.Error() == "no private interfaces" {
+		os.Exit(0)
+	}
 	failIfErr(err)
 
 	// setup droplan-peers chain for private interface


### PR DESCRIPTION
When testing out the new docker image on droplets without private iface, I noticed that it kept restarting without `sleep`ing.

If we are using `PUBLIC=true`, on a droplet without a private interface, `droplan` should exit with status code of 0.