### PR TITLE
docker: restore compatiblity with 1.2.0 image

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,15 +65,15 @@ We provide a prebuilt [docker image][1]
 Example usage:
 
 ```sh
-docker run -d --restart=always --net=host --cap-add=NET_ADMIN -e DO_KEY=$your_digitalocean_api_key tam7t/droplan
+docker run -d --restart=always --net=host --cap-add=NET_ADMIN -e DO_KEY=$your_digitalocean_api_key -e DO_INTERVAL=300 tam7t/droplan
 ```
 
 - `-d --restart=always` starts the container in the background and restarts it on error (and on reboot)
 - `--net=host` is required because we want to affect the host's firewall rules, not the container's
 - `--cap-add=NET_ADMIN` to allow changing the host's firewall rules
+- specify `-e DO_INTERVAL=300` to change the delay (in seconds) between droplan invocations (default: execute once and exit)
 - you have to specify your DigitalOcean API key (using `-e DO_KEY`)
 - you can add `-e PUBLIC=true` or `-e DO_TAG=tagname` as described above
-- specify `-e DO_INTERVAL=120` to change the delay between droplan invocations (default: '300' (5 minutes) ) 
 - To manually start droplan (i.e. skip the 5 minute delay between invocations), simply use `docker restart $container-name`
 
 

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -3,14 +3,15 @@
 set -ex
 
 if [ -z "$DO_INTERVAL" ]; then
-	# specifies the check interval
-	DO_INTERVAL=300
+	# if the interval is not set, only execute once
+	./droplan "$@"
+else
+	while true; do
+		# since we use 'set -e', this while loop will exit if droplan exits with a return value other than 0
+		# (which in turn tells docker to restart the container (assuming the --restart option was used)
+		# while delaying retries exponentially)
+		./droplan "$@"
+		sleep "$DO_INTERVAL"
+	done
 fi
 
-while true; do
-	# since we use 'set -e', this while loop will exit if droplan exits with a return value other than 0
-	# (which in turn tells docker to restart the container (assuming the --restart option was used)
-	# while delaying retries exponentially)
-	./droplan "$@"
-	sleep "$DO_INTERVAL"
-done


### PR DESCRIPTION
When testing PR #37 I realized that its usage was not compatible with the existing docker image. Here I default to existing behavior of running `droplan` once and only restarting it periodically if the `DO_INTERVAL` envvar is set.