### PR TITLE
makefile: static binary, do not require musl c

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,10 @@ build:
 	go build .
 
 build-amd64:
-	@docker run -it --rm -v `pwd`:/go/src/github.com/tam7t/droplan -w /go/src/github.com/tam7t/droplan golang:alpine env GOOS=linux GOARCH=amd64 go build -ldflags="-X main.appVersion=${DROPLAN_VERSION}" -o droplan
+	@docker run -it --rm -v `pwd`:/go/src/github.com/tam7t/droplan -w /go/src/github.com/tam7t/droplan golang:alpine env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-X main.appVersion=${DROPLAN_VERSION}" -o droplan
 
 build-i386:
-	@docker run -it --rm -v `pwd`:/go/src/github.com/tam7t/droplan -w /go/src/github.com/tam7t/droplan golang:alpine env GOOS=linux GOARCH=386 go build -ldflags="-X main.appVersion=${DROPLAN_VERSION}" -o droplan_i386
+	@docker run -it --rm -v `pwd`:/go/src/github.com/tam7t/droplan -w /go/src/github.com/tam7t/droplan golang:alpine env GOOS=linux GOARCH=386 CGO_ENABLED=0 go build -ldflags="-X main.appVersion=${DROPLAN_VERSION}" -o droplan_i386
 
 release: build-amd64 build-i386
 	@zip droplan_${DROPLAN_VERSION}_linux_amd64.zip droplan


### PR DESCRIPTION
droplan 1.3.0 is broken on ubuntu systems cause it is linked to musl c

```
root@droplan-ubuntu-x64:~# ldd /usr/local/bin/droplan
	linux-vdso.so.1 =>  (0x00007ffefc3ae000)
	libc.musl-x86_64.so.1 => not found
```